### PR TITLE
[Feat] 메이커 에셋 업그레이드 API - GPT만 이용

### DIFF
--- a/src/main/java/promptstudio/promptstudio/domain/maker/api/MakerController.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/api/MakerController.java
@@ -44,8 +44,18 @@ public class MakerController {
     @Operation(summary = "메이커 자동 저장", description = "메이커를 자동 저장합니다. (2초 debounce)")
     public ResponseEntity<MakerUpdateResponse> updateMaker(
             @PathVariable Long makerId,
-            @ModelAttribute MakerUpdateRequest request,
+            @RequestParam(value = "title", required = false) String title,
+            @RequestParam(value = "content", required = false) String content,
+            @RequestParam(value = "existingImageUrls", required = false) List<String> existingImageUrls,
             @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) {
+
+        // DTO 직접 생성
+        MakerUpdateRequest request = new MakerUpdateRequest();
+        request.setTitle(title);
+        request.setContent(content);
+        if (existingImageUrls != null) {
+            request.setExistingImageUrls(existingImageUrls);
+        }
 
         MakerUpdateResponse response = makerService.updateMaker(makerId, request, newImages);
 

--- a/src/main/java/promptstudio/promptstudio/domain/maker/api/MakerController.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/api/MakerController.java
@@ -8,11 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import promptstudio.promptstudio.domain.maker.application.MakerService;
-import promptstudio.promptstudio.domain.maker.dto.MakerCreateRequest;
-import promptstudio.promptstudio.domain.maker.dto.MakerCreateResponse;
-import promptstudio.promptstudio.domain.maker.dto.MakerDetailResponse;
-import promptstudio.promptstudio.domain.maker.dto.MakerUpdateRequest;
-import promptstudio.promptstudio.domain.maker.dto.MakerUpdateResponse;
+import promptstudio.promptstudio.domain.maker.dto.*;
 
 import java.net.URI;
 import java.util.List;
@@ -60,6 +56,16 @@ public class MakerController {
     @Operation(summary = "메이커 상세 조회", description = "메이커의 상세 정보를 조회합니다.")
     public ResponseEntity<MakerDetailResponse> getMakerDetail(@PathVariable Long makerId) {
         MakerDetailResponse response = makerService.getMakerDetail(makerId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{makerId}/upgrade-text")
+    @Operation(summary = "텍스트 업그레이드", description = "선택한 텍스트를 GPT로 업그레이드합니다.")
+    public ResponseEntity<TextUpgradeResponse> upgradeText(
+            @PathVariable Long makerId,
+            @RequestBody TextUpgradeRequest request) {
+
+        TextUpgradeResponse response = makerService.upgradeText(makerId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerService.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerService.java
@@ -1,10 +1,7 @@
 package promptstudio.promptstudio.domain.maker.application;
 
 import org.springframework.web.multipart.MultipartFile;
-import promptstudio.promptstudio.domain.maker.dto.MakerCreateRequest;
-import promptstudio.promptstudio.domain.maker.dto.MakerDetailResponse;
-import promptstudio.promptstudio.domain.maker.dto.MakerUpdateRequest;
-import promptstudio.promptstudio.domain.maker.dto.MakerUpdateResponse;
+import promptstudio.promptstudio.domain.maker.dto.*;
 
 import java.util.List;
 
@@ -14,4 +11,6 @@ public interface MakerService {
     MakerUpdateResponse updateMaker(Long makerId, MakerUpdateRequest request, List<MultipartFile> newImages);
 
     MakerDetailResponse getMakerDetail(Long makerId);
+
+    TextUpgradeResponse upgradeText(Long makerId, TextUpgradeRequest request);
 }

--- a/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
@@ -45,6 +45,7 @@ public class MakerServiceImpl implements MakerService {
     @Override
     @Transactional
     public MakerUpdateResponse updateMaker(Long makerId, MakerUpdateRequest request, List<MultipartFile> newImages) {
+        // TODO: 디버깅 로그이기에 나중에 삭제하기
         System.out.println("=== DEBUG ===");
         System.out.println("Title: " + request.getTitle());
         System.out.println("Content: " + request.getContent());

--- a/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
@@ -45,6 +45,16 @@ public class MakerServiceImpl implements MakerService {
     @Override
     @Transactional
     public MakerUpdateResponse updateMaker(Long makerId, MakerUpdateRequest request, List<MultipartFile> newImages) {
+        System.out.println("=== DEBUG ===");
+        System.out.println("Title: " + request.getTitle());
+        System.out.println("Content: " + request.getContent());
+        System.out.println("Content is null? " + (request.getContent() == null));
+
+        if (request.getContent() != null) {
+            System.out.println("Content length: " + request.getContent().length());
+            System.out.println("Content preview: " + request.getContent().substring(0, Math.min(50, request.getContent().length())));
+        }
+
         Maker maker = makerRepository.findById(makerId)
                 .orElseThrow(() -> new NotFoundException("메이커를 찾을 수 없습니다."));
 

--- a/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/application/MakerServiceImpl.java
@@ -45,17 +45,6 @@ public class MakerServiceImpl implements MakerService {
     @Override
     @Transactional
     public MakerUpdateResponse updateMaker(Long makerId, MakerUpdateRequest request, List<MultipartFile> newImages) {
-        // TODO: 디버깅 로그이기에 나중에 삭제하기
-        System.out.println("=== DEBUG ===");
-        System.out.println("Title: " + request.getTitle());
-        System.out.println("Content: " + request.getContent());
-        System.out.println("Content is null? " + (request.getContent() == null));
-
-        if (request.getContent() != null) {
-            System.out.println("Content length: " + request.getContent().length());
-            System.out.println("Content preview: " + request.getContent().substring(0, Math.min(50, request.getContent().length())));
-        }
-
         Maker maker = makerRepository.findById(makerId)
                 .orElseThrow(() -> new NotFoundException("메이커를 찾을 수 없습니다."));
 

--- a/src/main/java/promptstudio/promptstudio/domain/maker/dto/MakerUpdateRequest.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/dto/MakerUpdateRequest.java
@@ -2,12 +2,14 @@ package promptstudio.promptstudio.domain.maker.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class MakerUpdateRequest {
     private String title;

--- a/src/main/java/promptstudio/promptstudio/domain/maker/dto/TextUpgradeRequest.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/dto/TextUpgradeRequest.java
@@ -1,0 +1,11 @@
+package promptstudio.promptstudio.domain.maker.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TextUpgradeRequest {
+    private String selectedText;
+    private String direction;
+}

--- a/src/main/java/promptstudio/promptstudio/domain/maker/dto/TextUpgradeResponse.java
+++ b/src/main/java/promptstudio/promptstudio/domain/maker/dto/TextUpgradeResponse.java
@@ -1,0 +1,12 @@
+package promptstudio.promptstudio.domain.maker.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TextUpgradeResponse {
+    private String originalText;
+    private String upgradedText;
+    private String direction;
+}

--- a/src/main/java/promptstudio/promptstudio/global/config/ChatClientConfig.java
+++ b/src/main/java/promptstudio/promptstudio/global/config/ChatClientConfig.java
@@ -1,0 +1,17 @@
+package promptstudio.promptstudio.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class ChatClientConfig {
+
+    @Bean
+    @Primary
+    public ChatClient.Builder chatClientBuilder(OpenAiChatModel openAiChatModel) {
+        return ChatClient.builder(openAiChatModel);
+    }
+}

--- a/src/main/java/promptstudio/promptstudio/global/gpt/application/GptService.java
+++ b/src/main/java/promptstudio/promptstudio/global/gpt/application/GptService.java
@@ -1,0 +1,12 @@
+package promptstudio.promptstudio.global.gpt.application;
+
+public interface GptService {
+    /**
+     * 텍스트를 업그레이드합니다.
+     * @param selectedText 업그레이드할 텍스트
+     * @param direction 업그레이드 방향성
+     * @param fullContext 전체 프롬프트 내용 (맥락 파악용)
+     * @return 업그레이드된 텍스트
+     */
+    String upgradeText(String selectedText, String direction, String fullContext);
+}

--- a/src/main/java/promptstudio/promptstudio/global/gpt/application/GptServiceImpl.java
+++ b/src/main/java/promptstudio/promptstudio/global/gpt/application/GptServiceImpl.java
@@ -1,0 +1,69 @@
+package promptstudio.promptstudio.global.gpt.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class GptServiceImpl implements GptService {
+
+    private final ChatClient.Builder chatClientBuilder;
+
+    private static final String SYSTEM_MESSAGE = """
+            당신은 프롬프트 작성 전문가입니다.
+            사용자가 제공한 텍스트를 지정된 방향성에 맞게 개선해주세요.
+            개선된 텍스트만 출력하고, 추가 설명이나 인사말은 하지 마세요.
+            원본 텍스트의 핵심 의미는 유지하되, 방향성에 맞게 표현을 개선하세요.
+            """;
+
+    private static final String USER_MESSAGE_TEMPLATE = """
+            전체 맥락:
+            {fullContext}
+            
+            ---
+            
+            업그레이드할 텍스트:
+            {selectedText}
+            
+            개선 방향:
+            {direction}
+            
+            위 텍스트를 개선 방향에 맞게 다시 작성해주세요.
+            개선된 텍스트만 출력하세요.
+            """;
+
+    @Override
+    public String upgradeText(String selectedText, String direction, String fullContext) {
+        try {
+            ChatClient chatClient = chatClientBuilder.build();
+
+            PromptTemplate promptTemplate = new PromptTemplate(USER_MESSAGE_TEMPLATE);
+            Prompt prompt = promptTemplate.create(Map.of(
+                    "selectedText", selectedText,
+                    "direction", direction,
+                    "fullContext", fullContext != null ? fullContext : ""
+            ));
+
+            String result = chatClient.prompt(prompt)
+                    .system(SYSTEM_MESSAGE)
+                    .call()
+                    .content();
+
+            return result != null ? result.trim() : selectedText;
+
+        } catch (Exception e) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "텍스트 업그레이드 중 오류가 발생했습니다: " + e.getMessage(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/promptstudio/promptstudio/global/gpt/application/GptServiceImpl.java
+++ b/src/main/java/promptstudio/promptstudio/global/gpt/application/GptServiceImpl.java
@@ -17,27 +17,37 @@ public class GptServiceImpl implements GptService {
     private final ChatClient.Builder chatClientBuilder;
 
     private static final String SYSTEM_MESSAGE = """
-            당신은 프롬프트 작성 전문가입니다.
-            사용자가 제공한 텍스트를 지정된 방향성에 맞게 개선해주세요.
-            개선된 텍스트만 출력하고, 추가 설명이나 인사말은 하지 마세요.
-            원본 텍스트의 핵심 의미는 유지하되, 방향성에 맞게 표현을 개선하세요.
-            """;
+        당신은 프롬프트 작성 전문가입니다.
+        사용자가 제공한 텍스트를 지정된 방향성에 맞게 개선해주세요.
+        
+        중요한 규칙:
+        - 개선된 텍스트만 출력하고, 추가 설명이나 인사말은 절대 하지 마세요
+        - 원본 텍스트의 문장 구조, 어조, 시제를 최대한 유지하세요
+        - 원본과 비슷한 길이로 작성하세요 (너무 길거나 짧지 않게)
+        - 원본이 명사형이면 명사형으로, 동사형이면 동사형으로 유지하세요
+        - 전체 맥락 속에서 자연스럽게 들어갈 수 있도록 작성하세요
+        """;
 
     private static final String USER_MESSAGE_TEMPLATE = """
-            전체 맥락:
-            {fullContext}
-            
-            ---
-            
-            업그레이드할 텍스트:
-            {selectedText}
-            
-            개선 방향:
-            {direction}
-            
-            위 텍스트를 개선 방향에 맞게 다시 작성해주세요.
-            개선된 텍스트만 출력하세요.
-            """;
+        전체 맥락:
+        {fullContext}
+        
+        ---
+        
+        업그레이드할 텍스트:
+        {selectedText}
+        
+        개선 방향:
+        {direction}
+        
+        ---
+        
+        위 텍스트를 개선 방향에 맞게 다시 작성하되, 다음을 반드시 지켜주세요:
+        1. 원본의 문장 구조와 형식을 최대한 유지할 것
+        2. 전체 맥락에서 해당 부분이 자연스럽게 이어지도록 할 것
+        3. 원본과 비슷한 길이로 작성할 것
+        4. 개선된 텍스트만 출력하고 다른 말은 하지 말 것
+        """;
 
     @Override
     public String upgradeText(String selectedText, String direction, String fullContext) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,4 @@ server:
 
 spring:
   profiles:
-    active: local
+    active: prod

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,4 @@ server:
 
 spring:
   profiles:
-    active: prod
+    active: local


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- [ ] : 메이커 에셋 업그레이드 API

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 텍스트 업그레이드 기능 추가: 선택한 텍스트를 지정한 방향으로 개선하고 원본/개선된 텍스트를 함께 제공합니다.
* **개선 사항**
  * 텍스트 업그레이드 처리 경로와 서비스 연동을 통해 보다 일관된 편집 경험 제공.
  * 내부 구성과 DI 설정 개선으로 안정성 및 응답 신뢰도 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->